### PR TITLE
⚡ Bolt: [performance improvement] Lazy load images below the fold

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - No Package Manager Found
+**Learning:** This is a static HTML/CSS/JS site running directly from files. There is no `package.json`, `npm`, or `pnpm` available, meaning standard Node-based linting or testing tools cannot be run.
+**Action:** Do not attempt to run `pnpm lint` or `pnpm test` as instructed by the generic Bolt prompt, as they will fail. Rely on manual verification (e.g., Python HTTP server) and native browser features for performance optimizations.

--- a/index.html
+++ b/index.html
@@ -155,8 +155,9 @@
                 <div class="flex items-start space-x-4 mb-8">
                     <div
                         class="w-14 h-14 rounded-full bg-gray-300 overflow-hidden flex-shrink-0 border-2 border-white shadow-sm z-10 relative">
+                        <!-- ⚡ Bolt: Lazy load below-the-fold founder image -->
                         <img src="https://placehold.co/100x100/333/fff?text=AM" alt="Founder"
-                            class="w-full h-full object-cover">
+                            class="w-full h-full object-cover" loading="lazy" decoding="async">
                     </div>
                     <div>
                         <div class="overflow-hidden">
@@ -229,8 +230,9 @@
                     </div>
                 </div>
                 <!-- Placeholder Image -->
+                <!-- ⚡ Bolt: Lazy load video placeholder image -->
                 <img src="https://placehold.co/800x450/1f2937/fff?text=Build+In+Public+Series"
-                    class="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition duration-500 scale-100 group-hover:scale-105">
+                    class="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition duration-500 scale-100 group-hover:scale-105" loading="lazy" decoding="async">
             </div>
         </div>
     </section>
@@ -250,8 +252,9 @@
                     class="work-card group relative bg-white rounded-xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-500 border border-gray-100 gsap-reveal">
                     <!-- Image Area -->
                     <div class="h-64 overflow-hidden relative">
+                        <!-- ⚡ Bolt: Lazy load project 1 image -->
                         <img src="https://placehold.co/800x600/333/fff?text=SaaS+Dashboard" alt="Project 1"
-                            class="work-image w-full h-full object-cover transition-transform duration-700">
+                            class="work-image w-full h-full object-cover transition-transform duration-700" loading="lazy" decoding="async">
                         <div
                             class="work-overlay absolute inset-0 bg-black/60 opacity-0 transition-opacity duration-300 flex items-center justify-center">
                             <span
@@ -292,8 +295,9 @@
                     class="work-card group relative bg-white rounded-xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-500 border border-gray-100 gsap-reveal">
                     <!-- Image Area -->
                     <div class="h-64 overflow-hidden relative">
+                        <!-- ⚡ Bolt: Lazy load project 2 image -->
                         <img src="https://placehold.co/800x600/FF3B3F/fff?text=Market+Validator" alt="Project 2"
-                            class="work-image w-full h-full object-cover transition-transform duration-700">
+                            class="work-image w-full h-full object-cover transition-transform duration-700" loading="lazy" decoding="async">
                         <div
                             class="work-overlay absolute inset-0 bg-black/60 opacity-0 transition-opacity duration-300 flex items-center justify-center">
                             <span


### PR DESCRIPTION
💡 What: Added `loading="lazy"` and `decoding="async"` attributes to image tags located below the fold (founder profile, video placeholder, and project thumbnails).
🎯 Why: Browsers download all `<img>` tags by default during initial page load, even if they aren't visible on the screen. This consumes user bandwidth, delays rendering of critical assets, and blocks the main thread during image decoding.
📊 Impact: Expected reduction in initial bytes downloaded (approx. 4 large placeholder images saved). Improves Time to Interactive (TTI) and First Contentful Paint (FCP) by unblocking the main thread during initial load.
🔬 Measurement: Open Chrome DevTools -> Network Panel. Select "Disable Cache" and set throttling to "Fast 3G". Refresh the page. You will observe that the images below the fold are only requested when scrolling down to their respective sections.

---
*PR created automatically by Jules for task [16240405522770306778](https://jules.google.com/task/16240405522770306778) started by @anselmeM*