### PR TITLE
Fix toggleFaq lazy-caching SSR errors and stale test references

### DIFF
--- a/patch_script_test.js
+++ b/patch_script_test.js
@@ -1,0 +1,49 @@
+--- tests/script.test.js
++++ tests/script.test.js
+@@ -51,13 +51,15 @@
+     offsetTop: 100
+ };
+
++const mockExitPopupGlobal = {
++    addEventListener: jest.fn(),
++    querySelectorAll: jest.fn(() => []),
++    classList: { contains: jest.fn(), add: jest.fn(), remove: jest.fn() }
++};
++
+ global.document = {
+     getElementById: jest.fn((id) => {
+         if (id === 'exit-intent-popup') {
+-            return {
+-                addEventListener: jest.fn(),
+-                querySelectorAll: jest.fn(() => []),
+-                classList: { contains: jest.fn(), add: jest.fn(), remove: jest.fn() }
+-            };
++            return mockExitPopupGlobal;
+         }
+         return null;
+     }),
+@@ -161,15 +163,8 @@
+         };
+         const mockEmailInput = { value: 'test@example.com' };
+
+-        const mockExitPopup = {
+-            classList: {
+-                remove: jest.fn()
+-            }
+-        };
+-
+         elements['lead-capture-form'] = mockForm;
+         elements['lead-email'] = mockEmailInput;
+-        elements['exit-intent-popup'] = mockExitPopup;
+
+         const mockEvent = { preventDefault: jest.fn() };
+
+@@ -192,7 +187,7 @@
+         jest.runAllTimers();
+
+         // Ensure closeExitPopup was called
+-        expect(mockExitPopup.classList.remove).toHaveBeenCalledWith('active');
++        expect(mockExitPopupGlobal.classList.remove).toHaveBeenCalledWith('active');
+
+         jest.useRealTimers();
+     });

--- a/script.js
+++ b/script.js
@@ -68,9 +68,16 @@ gsap.to(".founder-anim", {
 // The toggleMobileMenu function is defined in navbar.js
 
 // 7. FAQ TOGGLE LOGIC
+/** @type {NodeListOf<Element> | null} */
+toggleFaq.cachedItems = null;
+
 function toggleFaq(element) {
+    if (typeof document === 'undefined') return;
+    if (!toggleFaq.cachedItems) {
+        toggleFaq.cachedItems = document.querySelectorAll(".faq-item");
+    }
     const isActive = element.classList.contains("active");
-    document.querySelectorAll(".faq-item").forEach((item) => {
+    toggleFaq.cachedItems.forEach((item) => {
         item.classList.remove("active");
     });
     if (!isActive) {

--- a/tests/faq.test.js
+++ b/tests/faq.test.js
@@ -102,6 +102,7 @@ describe('toggleFaq', () => {
         faq3 = new MockElement('faq3');
         mockElements = [faq1, faq2, faq3];
         jest.clearAllMocks();
+        toggleFaq.cachedItems = null;
     });
 
     test('should activate an inactive FAQ item and deactivate others', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -50,14 +50,16 @@ const mockElement = {
     offsetTop: 100
 };
 
+const mockExitPopupGlobal = {
+    addEventListener: jest.fn(),
+    querySelectorAll: jest.fn(() => []),
+    classList: { contains: jest.fn(), add: jest.fn(), remove: jest.fn() }
+};
+
 global.document = {
     getElementById: jest.fn((id) => {
         if (id === 'exit-intent-popup') {
-            return {
-                addEventListener: jest.fn(),
-                querySelectorAll: jest.fn(() => []),
-                classList: { contains: jest.fn(), add: jest.fn(), remove: jest.fn() }
-            };
+            return mockExitPopupGlobal;
         }
         return null;
     }),
@@ -159,15 +161,8 @@ describe('handleLeadCapture', () => {
         };
         const mockEmailInput = { value: 'test@example.com' };
 
-        const mockExitPopup = {
-            classList: {
-                remove: jest.fn()
-            }
-        };
-
         elements['lead-capture-form'] = mockForm;
         elements['lead-email'] = mockEmailInput;
-        elements['exit-intent-popup'] = mockExitPopup;
 
         const mockEvent = { preventDefault: jest.fn() };
 
@@ -191,7 +186,7 @@ describe('handleLeadCapture', () => {
         jest.runAllTimers();
 
         // Ensure closeExitPopup was called
-        expect(mockExitPopup.classList.remove).toHaveBeenCalledWith('active');
+        expect(mockExitPopupGlobal.classList.remove).toHaveBeenCalledWith('active');
 
         jest.useRealTimers();
     });


### PR DESCRIPTION
This PR fixes the CI/CD pipeline failure introduced by the recent `toggleFaq` optimization commit.

Changes made:
-   **SSR Safety:** Added `if (typeof document === 'undefined') return;` to `toggleFaq` to prevent `ReferenceError` during server-side rendering.
-   **Type Safety & Linting:** Added `/** @type {NodeListOf<Element> | null} */` to strongly type the cached NodeList. Attached the cache to the function object itself (`toggleFaq.cachedItems`) instead of using a top-level variable (`let cachedFaqItems;`) to satisfy linter rules preventing module-level mutations outside the component lifecycle.
-   **Stale Test References:** Added `toggleFaq.cachedItems = null;` to the `beforeEach` block in `tests/faq.test.js` to ensure the DOM query executes properly on fresh mock elements for every test case.
-   **Test Fix:** Fixed an unrelated failing test (`handleLeadCapture` in `tests/script.test.js`) where the assertion was checking a local, unutilized test mock rather than the top-level `exit-intent-popup` mock captured by the script when imported.

All tests now pass successfully.

---
*PR created automatically by Jules for task [1475622995409100339](https://jules.google.com/task/1475622995409100339) started by @anselmeM*